### PR TITLE
Update Throttling sends to reflect correct count

### DIFF
--- a/v5/0.mailcoach/7.advanced-usage-for-php-devs/2.throttling-sends.md
+++ b/v5/0.mailcoach/7.advanced-usage-for-php-devs/2.throttling-sends.md
@@ -2,7 +2,7 @@
 title: Throttling sends
 ---
 
-Most email providers have a limit on how many emails you can send within a given amount of time. By default, five mails per second will be sent. In the config file you can customize this behavior by changing the `throttling` key:
+Most email providers have a limit on how many emails you can send within a given amount of time. By default, ten mails per second will be sent. In the config file you can customize this behavior by changing the `throttling` key:
 
 ```php
 'throttling' => [


### PR DESCRIPTION
The text currently says five emails per second but the value in the screenshot says 10, so I have updated the content to reflect the same